### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -28,12 +28,23 @@ global.sleep = (time: number) => {
 export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    const challengeEnabled = utils.isChallengeEnabled(challenges.noSqlCommandChallenge)
+    // Use strict number casting if challenge is not enabled, otherwise safe string truncation
+    const id = challengeEnabled ? utils.trunc(req.params.id, 40) : Number(req.params.id)
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    let query
+    if (challengeEnabled) {
+      // Compare as string, don't allow code injection (still allow DoS via sleep, etc.)
+      query = { product: id }
+    } else {
+      // Compare as number
+      query = { product: id }
+    }
+
+    db.reviewsCollection.find(query).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/richardmta23/juice-shop23/security/code-scanning/53](https://github.com/richardmta23/juice-shop23/security/code-scanning/53)

To fix this problem, we must ensure that user input is never directly concatenated into a string that is interpreted as code (here, a JavaScript expression for the `$where` operator). Instead of using `$where` with a concatenated string, use a regular MongoDB query where possible, e.g., `{ product: value }`, and strictly validate and convert the input to the expected type (number). For the challenge path (when `noSqlCommandChallenge` is enabled), if arbitrary input is required for challenge purposes but you must still avoid remote code execution, sanitize the input so that it is only compared as a value (not allowed to inject JS code fragments).

- In `routes/showProductReviews.ts`:
  - Replace the vulnerable use of `$where` with a safer `{ product: value }` query when the challenge is **not** enabled.
  - When the challenge is enabled (i.e., when using truncation), restrict the query as much as possible (for example, treat the id as a string and only match exact product strings, not evaluate code).
  - Ensure that in both cases, the input is either safely cast to number or compared literally.

No other files require changing for this specific fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
