### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/richardmta23/juice-shop23/security/code-scanning/54](https://github.com/richardmta23/juice-shop23/security/code-scanning/54)

To fix this code injection vulnerability, we must eliminate the use of user input in a context where it is interpreted as code. Specifically, we need to avoid interpolating user input into the string passed to the MongoDB `$where` operator. Instead, we should use standard query operators, such as `{ orderId: id }`. This style of query treats the input as data, not executable code, preventing the possibility of injection.

The replacement for:
```js
db.ordersCollection.find({ $where: `this.orderId === '${id}'` })
```
should be:
```js
db.ordersCollection.find({ orderId: id })
```
This ensures that the query engine safely compares the `orderId` field to the value of `id` without executing arbitrary code.

The fix should be made in `routes/trackOrder.ts`, specifically replacing line 18 as described. No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
